### PR TITLE
Initial authentication check fails when HipChat API URL is overridden

### DIFF
--- a/hipchat.py
+++ b/hipchat.py
@@ -26,7 +26,8 @@ def hipchat_list(keys):
     for key in keys:
         api_key = str(key)
         try:
-            hipchat_auth = web.get('https://api.hipchat.com/v2/room?auth_token=' +
+            hipchat_auth = web.get(wflw.settings['api_url'] + 
+                                   '/v2/room?auth_token=' +
                                    api_key + '&auth_test=true',
                                    None,
                                    timeout=wflw.settings['timeout'])


### PR DESCRIPTION
### Motivation
When user overrides `api_url` the initial auth check is still performed hitting `api.hipchat.com`. 
That check fails since `api.hipchat.com` knows nothing about enterprise accounts. 

### Reviewers 
- [ ] @zsprackett 